### PR TITLE
Import portability and Verbosity Solved

### DIFF
--- a/Parser/parser.h
+++ b/Parser/parser.h
@@ -63,26 +63,28 @@ bool file_exists(str filename){
     }
     return is_exist;
 }
-
-//This function will manage the imports.
-array<str> ImportsManagement(array<str> tok){
-    /*Sample input: import m1.m2 m3
-    Tokens: ['m1','.','m2']
+str currDir;
+array<str> ImportsManagement(array<str> tok, str base_path = "./") {
+    /*
+    Syntax: import <module>
+    Sample tokens : {"import","test"}
     */
-    array<str> imp;
-    str s;
-    bool dir = false;
-    for(auto i : tok){
-        if(i == IMPORT){}
-        else{
-            str name_module = split(i,"/")[split(i,"/").len()-1];
-            imp.add(
-                str("namespace ")+name_module+str(" LBRACE\n")+read(i+".csqm")+str("\nRBRACE\n")
-            );
-        }
+    str path = tok[1];
+    array<str> tokens;
+    if(path[0] == '/'){}
+    else{
+        path = base_path + path;
     }
-    return imp;
+    str content = read(currDir+str("/")+path+".csqm");
+    str name = split(path,"/")[split(path,"/").len()-1];
+    str code = "namespace ";
+    code += name + " LBRACE\n";
+    code += content + "\n RBRACE";
+    tokens.add(code);
+    return tokens;
 }
+
+
 array<str> IfTokManagement(array<str> tok){
     array<str> s;
     if(CheckIF(tok) == 1){
@@ -168,7 +170,7 @@ str Rep(str s){
     code = replaceStr(code.Str,"- >","->");
     code = replaceStr(code.Str,"& &","&&");
     code = replaceStr(code.Str," . ",".");
-    code = replaceStr(code.Str,": :","::");
+    //code = replaceStr(code.Str,": :","::");
     code = replaceStr(code.Str," ,",",");
     return code;
 }

--- a/csq.cpp
+++ b/csq.cpp
@@ -15,6 +15,7 @@ int main(int argc, char const *argv[])
         // Reading code:
         str name = argv[1];
         str currentpath = argv[2];
+        currDir = currentpath;
         str compiler_path = argv[3];
         str code = read(currentpath+str("/")+name+".csq");
         ///////////////////////////////////////////////////////////////////

--- a/libs/utils/filehand.h
+++ b/libs/utils/filehand.h
@@ -1,15 +1,14 @@
 #if !defined(filehand_utils_Csq3)
 #define filehand_utils_Csq3
     #include "str.h"
-
-    //This function is gonna read the text present in the file.
+    #include <unistd.h>
     auto read(str filepath, int line_num = 10000){
         FILE * fo; 
         fo = fopen(filepath.Str,"r");
         str data;
         char ln[line_num];
         /*File is opened. Start reading the file line by line.*/
-        while ( fgets ( ln, 1000, fo) != NULL ){
+        while ( fgets ( ln, line_num, fo) != NULL ){
             data += str(ln);
         }
         fclose(fo);


### PR DESCRIPTION
As earlier we have to write whole path while importing a module like this 
```
import /home/.......temp
```
But now after improvement in parser it's like:
```
import temp
```